### PR TITLE
Never pick more items than is in the array

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ shuffle.pick = function(arr, options) {
         random = [],
         index;
 
-    while (picks) {
+    while (picks && len) {
       index = Math.floor(rng() * len);
       random.push(collection[index]);
       collection.splice(index, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -86,4 +86,10 @@ describe('shuffle-array.pick()', function () {
       assert(Array.isArray(newCollection));
       assert(collection.indexOf(newCollection[0]) !== -1);
     });
+    
+    it('should not return more items than what is in the array', function() {
+      var newCollection = shuffle.pick(collection, {'picks': collection.length + 5});
+      
+      assert(newCollection.length == collection.length);
+    });
 });


### PR DESCRIPTION
Currently if picks is greater than the array length it returns the array items + undefined for the extra items. This fixes that so that it returns the entire array shuffled if you pick too many items.